### PR TITLE
Convert internals to use Moo and Moo compatible types

### DIFF
--- a/lib/Role/Identifiable/HasIdent.pm
+++ b/lib/Role/Identifiable/HasIdent.pm
@@ -1,5 +1,8 @@
 package Role::Identifiable::HasIdent;
-use Moose::Role;
+
+use Types::Standard qw(Str);
+use Type::Utils qw(declare as where);
+use Moo::Role;
 # ABSTRACT: a thing with an ident attribute
 
 =head1 DESCRIPTION
@@ -12,14 +15,13 @@ with whitespace.
 
 =cut
 
-use Moose::Util::TypeConstraints;
-
 has ident => (
   is  => 'ro',
-  isa => subtype('Str', where { length && /\A\S/ && /\S\z/ }),
+  isa => declare(as Str, where { length && /\A\S/ && /\S\z/ }),
   required => 1,
 );
 
-no Moose::Role;
-use Moose::Util::TypeConstraints;
+no Moo::Role;
+no Types::Standard;
+no Type::Utils;
 1;

--- a/lib/Role/Identifiable/HasTags.pm
+++ b/lib/Role/Identifiable/HasTags.pm
@@ -1,5 +1,11 @@
 package Role::Identifiable::HasTags;
-use Moose::Role;
+
+use Type::Utils -all;
+use Types::Standard qw(Str ArrayRef);
+our $_Tag = declare 'Tag', as Str, where { length };
+
+
+use Moo::Role;
 # ABSTRACT: a thing with a list of tags
 
 =head1 OVERVIEW
@@ -12,7 +18,6 @@ The behavior of this role is not yet very stable.  Do not rely on it yet.
 
 =cut
 
-use Moose::Util::TypeConstraints;
 
 sub has_tag {
   my ($self, $tag) = @_;
@@ -32,11 +37,9 @@ sub tags {
   return wantarray ? keys %tags : (keys %tags)[0];
 }
 
-subtype 'Role::Identifiable::_Tag', as 'Str', where { length };
-
 has instance_tags => (
   is     => 'ro',
-  isa    => 'ArrayRef[Role::Identifiable::_Tag]',
+  isa    => ArrayRef[ $_Tag ],
   reader => '_instance_tags',
   init_arg => 'tags',
   default  => sub { [] },
@@ -66,6 +69,8 @@ sub _build_default_tags {
   return \@tags;
 }
 
-no Moose::Util::TypeConstraints;
-no Moose::Role;
+no Moo::Role;
+no Type::Utils;
+no Types::Standard;
+
 1;

--- a/t/idents.t
+++ b/t/idents.t
@@ -5,7 +5,7 @@ use Test::More;
 
 {
   package Some::Identifiable;
-  use Moose;
+  use Moo;
 
   with(qw(
     Role::Identifiable::HasTags


### PR DESCRIPTION
_mostly_ straightforward porting. 

Not sure about the type logic exactly though.

N.B. Third Party `use` declarations performed intentionally **BEFORE** `use Moo::Role`, as this is the standard work-around to prevent `Moo::Role` treating `import()`'d subs as methods that need to be reapplied to child classes.
